### PR TITLE
Drop support for Python 3.7 and 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,15 +17,13 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering :: Astronomy"
 ]
 license = { text = "NOSA" }
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = ["astropy", "numpy"]
 dynamic = [ "version" ]
 


### PR DESCRIPTION
The most recent versions of Astropy require Python >= 3.9.