### PR TITLE
Added support for Apple Silicon builds in Github Actions

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -92,21 +92,7 @@ jobs:
         # support for cross-compilation to arm64 targets
         # and change environment variables for the compiler
         # to utilise them. Added by @kokroo (Shiv Kokroo)
-        run: |
-          curl -L -O https://github.com/isuruf/gcc/releases/download/gcc-10-arm-20210728/gfortran-darwin-arm64.tar.gz
-          sudo mkdir -p /opt/
-          sudo cp "gfortran-darwin-arm64.tar.gz" /opt/gfortran-darwin-arm64.tar.gz
-          pushd /opt
-                sudo tar -xvf gfortran-darwin-arm64.tar.gz
-                sudo rm gfortran-darwin-arm64.tar.gz
-          popd
-          export FC_ARM64="$(find /opt/gfortran-darwin-arm64/bin -name "*-gfortran")"
-          libgfortran="$(find /opt/gfortran-darwin-arm64/lib -name libgfortran.dylib)"
-          libdir=$(dirname $libgfortran)
-          export FC_ARM64_LDFLAGS="-L$libdir -Wl,-rpath,$libdir"
-          export SDKROOT=$(xcrun -sdk macosx --show-sdk-path) 
-          export CIBW_ENVIRONMENT_MACOS="FC=$FC_ARM64 F90=$FC_ARM64 F77=$FC_ARM64 LDFLAGS=\" -arch arm64 $FC_ARM64_LDFLAGS\" CFLAGS=\" -arch arm64\" CXXFLAGS=\" -arch arm64\" CPPFLAGS=\" -arch arm64\" _PYTHON_HOST_PLATFORM=macosx-11.0-arm64 ARCHFLAGS=\" -arch arm64\" FCFLAGS=\" -arch arm64\" CROSS_COMPILING=1 host_alias=aarch64-apple-darwin20.0.0  MACOSX_DEPLOYMENT_TARGET=11.0 SDKROOT=$SDKROOT"
-          echo "CIBW_ENVIRONMENT_MACOS=$CIBW_ENVIRONMENT_MACOS" >> $GITHUB_ENV
+        uses: kokroo/cross-compile-fortran-macos@v1
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.14

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -26,12 +26,12 @@ jobs:
         with:
           path: dist/*
 
-  wheels:
-    name: Build binary packages
+  linux-wheels:
+    name: Build binary packages for Linux
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v3
@@ -46,11 +46,75 @@ jobs:
         uses: pypa/cibuildwheel@v2.14
         env:
           CIBW_ARCHS_LINUX: auto aarch64
-          CIBW_ENVIRONMENT_MACOS: F77=gfortran-11 F90=gfortran-11
           # Skip musllinux wheels, which take a long time to build because Numpy must be built from source
           # Skip PyPy wheels
           # Skip 32-bit Intel wheels
-          CIBW_SKIP: '*musllinux* pp* *_i686'
+          CIBW_SKIP: "*musllinux* pp* *_i686"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: wheelhouse/*
+
+  mac-wheels-x86:
+    name: Build binary packages for macOS x86
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.14
+        env:
+          CIBW_ARCHS_MACOS: "x86_64"
+          CIBW_ENVIRONMENT_MACOS: F77=gfortran-11 F90=gfortran-11
+          # Skip PyPy wheels
+          # Skip 32-bit Intel wheels
+          CIBW_SKIP: "pp* *_i686"
+      - uses: actions/upload-artifact@v3
+        with:
+          path: wheelhouse/*
+
+  mac-wheels-arm64:
+    name: Build binary packages for macOS arm64
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup gfortran for macOS arm64
+        if: matrix.os == 'macos-latest'
+        # Here, we fetch a forked gfortran compiler with
+        # support for cross-compilation to arm64 targets
+        # and change environment variables for the compiler
+        # to utilise them. Added by @kokroo (Shiv Kokroo)
+        run: |
+          curl -L -O https://github.com/isuruf/gcc/releases/download/gcc-10-arm-20210728/gfortran-darwin-arm64.tar.gz
+          sudo mkdir -p /opt/
+          sudo cp "gfortran-darwin-arm64.tar.gz" /opt/gfortran-darwin-arm64.tar.gz
+          pushd /opt
+                sudo tar -xvf gfortran-darwin-arm64.tar.gz
+                sudo rm gfortran-darwin-arm64.tar.gz
+          popd
+          export FC_ARM64="$(find /opt/gfortran-darwin-arm64/bin -name "*-gfortran")"
+          libgfortran="$(find /opt/gfortran-darwin-arm64/lib -name libgfortran.dylib)"
+          libdir=$(dirname $libgfortran)
+          export FC_ARM64_LDFLAGS="-L$libdir -Wl,-rpath,$libdir"
+          export SDKROOT=$(xcrun -sdk macosx --show-sdk-path) 
+          export CIBW_ENVIRONMENT_MACOS="FC=$FC_ARM64 F90=$FC_ARM64 F77=$FC_ARM64 LDFLAGS=\" -arch arm64 $FC_ARM64_LDFLAGS\" CFLAGS=\" -arch arm64\" CXXFLAGS=\" -arch arm64\" CPPFLAGS=\" -arch arm64\" _PYTHON_HOST_PLATFORM=macosx-11.0-arm64 ARCHFLAGS=\" -arch arm64\" FCFLAGS=\" -arch arm64\" CROSS_COMPILING=1 host_alias=aarch64-apple-darwin20.0.0  MACOSX_DEPLOYMENT_TARGET=11.0 SDKROOT=$SDKROOT"
+          echo "CIBW_ENVIRONMENT_MACOS=$CIBW_ENVIRONMENT_MACOS" >> $GITHUB_ENV
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.14
+        env:
+          CIBW_ARCHS_MACOS: "arm64"
+          CIBW_TEST_SKIP: "*-macosx_arm64"
+          # Skip PyPy wheels
+          CIBW_SKIP: "pp*"
 
       - uses: actions/upload-artifact@v3
         with:
@@ -61,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-    needs: [source, wheels]
+    needs: [source, linux-wheels, mac-wheels-x86, mac-wheels-arm64]
     if: github.event_name == 'release'
     steps:
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
I've successfully added Apple Silicon support for Radbelt. I used an open-source fork of gfortran which can cross-compile to Apple Silicon.

I had to separate Linux, macOS Intel, and macOS ARM builds because there was no way to figure out which platform and architecture is being targeted by cibuildwheel, in the midst of a Github Action workflow.

Below is a screenshot of Radbelt installed from the wheel found in the artifacts of the Github Runner running natively on my M1 Macbook Pro. There's an infinitesimal variation in the calculation due to the lower precision inherent in Apple Silicon and also due to the fact that the Fortran compiler is still not optimized to handle higher precision. I will try to rectify this sometime soon by looking into the forked compiler and seeing how it translates integer and float types to ARM binary code.

<img width="995" alt="Screenshot 2023-08-15 at 06 45 03" src="https://github.com/nasa/radbelt/assets/6683709/d1c73b68-d775-4700-b3ef-be27cb5b0c72">

Fixes #3 
@lpsinger 
