### PR TITLE
Build wheels for macOS arm64 using macos-*-xlarge runners

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, macos-latest-xlarge, windows-latest]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #3.