### PR TITLE
Build wheels for macOS arm64 using GitHub free tier runners

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, macos-14, windows-latest]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub just announced free Apple Silicon runners for open-source projects: https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

Fixes #3.