### PR TITLE
Assign unique artifact name to each GitHub Actions job

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -22,6 +22,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: source
           path: dist/*
 
   wheels:
@@ -60,6 +61,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: ${{ matrix.os }}
           path: wheelhouse/*
 
   publish:
@@ -72,6 +74,6 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          merge-multiple: true
           path: dist
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
[actions/upload-artifact@v4](https://github.com/actions/upload-artifact) no longer supports multiple artifacts with the same name.